### PR TITLE
Bugfixes to get it working with CCL

### DIFF
--- a/coleslaw.asd
+++ b/coleslaw.asd
@@ -5,8 +5,13 @@
   :license "BSD"
   :author "Brit Butler <redline6561@gmail.com>"
   :pathname "src/"
-  :depends-on (:closure-template :3bmd :3bmd-ext-code-blocks
-               :alexandria :local-time :trivial-shell :cl-fad)
+  :depends-on (:closure-template 
+               :3bmd 
+               :3bmd-ext-code-blocks
+               :alexandria 
+               :local-time 
+               :inferior-shell 
+               :cl-fad)
   :serial t
   :components ((:file "packages")
                (:file "util")

--- a/example-ccl.post-receive
+++ b/example-ccl.post-receive
@@ -1,0 +1,9 @@
+GIT_REPO=$HOME/lisp-is-fun.git
+# TMP_GIT_CLONE _must_ match the :repo arg in coleslawrc excluding trailing slash
+TMP_GIT_CLONE=$HOME/lisp-is-fun/tmp
+
+git clone $GIT_REPO $TMP_GIT_CLONE
+echo "(ql:quickload :coleslaw)
+(coleslaw:main)" | ccl -b
+rm -Rf $TMP_GIT_CLONE
+exit

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -8,7 +8,7 @@ If ARGS is provided, use (apply 'format nil PATH ARGS) as the value of PATH."
 (defun run-program (program &rest args)
   "Take a PROGRAM and execute the corresponding shell command. If ARGS is provided,
 use (apply 'format nil PROGRAM ARGS) as the value of PROGRAM."
-  (trivial-shell:shell-command (apply 'format nil program args)))
+  (inferior-shell:run (apply 'format nil program args) :show t))
 
 (defun update-symlink (path target)
   "Update the symlink at PATH to point to TARGET."
@@ -28,7 +28,7 @@ on files that match the given extension."
 (defun current-directory ()
   "Return the operating system's current directory."
   #+sbcl (sb-posix:getcwd)
-  #+ccl (current-directory)
+  #+ccl (ccl:current-directory)
   #+ecl (si:getcwd)
   #+cmucl (unix:unix-current-directory)
   #+clisp (ext:cd)
@@ -37,7 +37,7 @@ on files that match the given extension."
 (defun (setf current-directory) (path)
   "Change the operating system's current directory to PATH."
   #+sbcl (sb-posix:chdir path)
-  #+ccl (setf (current-directory) path)
+  #+ccl (setf (ccl:current-directory) path)
   #+ecl (si:chdir path)
   #+cmucl (unix:unix-chdir (namestring path))
   #+clisp (ext:cd path)


### PR DESCRIPTION
Some minor bugs were causing Coleslaw to break when running on CCL. Also, I replaced trivial-shell with inferior-shell because the latter is better maintained and the former is buggy on CCL.
