### PR TITLE
Fixed issue with " ," rendered instead of ", "

### DIFF
--- a/themes/hyde/index.tmpl
+++ b/themes/hyde/index.tmpl
@@ -17,8 +17,8 @@
 <div id="tagsoup">
   <p>This blog covers
     {foreach $tag in $tags}
-      <a href="{$config.domain}/tag/{$tag}.html">{$tag}</a>
-      {if not isLast($tag)}, {/if}
+      <a href="{$config.domain}/tag/{$tag}.html">{$tag}</a>{nil}
+      {if not isLast($tag)},{sp}{/if}
     {/foreach}
 </div>
 {/if}
@@ -26,8 +26,8 @@
 <div id="monthsoup">
   <p>View posts from
     {foreach $month in $months}
-      <a href="{$config.domain}/date/{$month}.html">{$month}</a>
-      {if not isLast($month)}, {/if}
+      <a href="{$config.domain}/date/{$month}.html">{$month}</a>{nil}
+      {if not isLast($month)},{sp}{/if}
     {/foreach}
 </div>
 {/if}

--- a/themes/hyde/post.tmpl
+++ b/themes/hyde/post.tmpl
@@ -5,8 +5,8 @@
   <h1 class="title">{$post.title}</h1>{\n}
   <div class="tags">{\n}
     Tagged as {foreach $tag in $post.tags}
-                <a href="../tag/{$tag}.html">{$tag}</a>
-                    {if not isLast($tag)}, {/if}
+                <a href="../tag/{$tag}.html">{$tag}</a>{nil}
+                    {if not isLast($tag)},{sp}{/if}
               {/foreach}
   </div>{\n}
   <div class="date">{\n}


### PR DESCRIPTION
If you look at the generated pages in the lines:

This blog covers ....

and 

View posts from ...

you see that the ... is formatted as:  math ,lisp ,tag ...
instead of : math, lisp, tag, ...

This patch should fix that.  
