### PR TITLE
*injections* was never set to nil, so kept growing indefinetely

### DIFF
--- a/src/coleslaw.lisp
+++ b/src/coleslaw.lisp
@@ -75,8 +75,9 @@ Additional args to render CONTENT can be passed via RENDER-ARGS."
 (defun main (config-key)
   "Load the user's config section corresponding to CONFIG-KEY, then
 compile and deploy the blog."
-  (load-config config-key)
-  (load-content)
-  (compile-theme (theme *config*))
-  (compile-blog (staging *config*))
-  (deploy (staging *config*)))
+  (let (*injections*) 
+    (load-config config-key)
+    (load-content)
+    (compile-theme (theme *config*))
+    (compile-blog (staging *config*))
+    (deploy (staging *config*))))


### PR DESCRIPTION
If you in the REPL do repeatedly (coleslaw:main ...) the _injections_ list keeps growing and the generated HTML contains old injections.

Wim Oudshoorn
