### PR TITLE
Mathjax improvements

### DIFF
--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -30,7 +30,7 @@
 
 `:config` allows the specification of the config parameter of `MathJax.js`.  The default value is `"TeX-AMS-MML_HTMLorMML"`.  
 
-`:mathjax-config` allows specifying the content of the `...` in a `MathJax.Hub.Config ({ ... });` section.  The default is `tex2jax: {inlineMath: [['$$','$$']]}`, which allows display equations to be enclosed in `$$`. 
+`:mathjax-config` allows specifying the content of the `...` in a `MathJax.Hub.Config ({ ... });` section.  The default is `tex2jax: {inlineMath: [['$$','$$']]}`, which allows display equations to be enclosed in `$$`.  If a `nil` argument is supplied the whole `<script>` section containing the `MathJax.Hub.Config` will be omitted.
 
 ## ReStructuredText
 

--- a/plugins/mathjax.lisp
+++ b/plugins/mathjax.lisp
@@ -42,7 +42,7 @@ src=\"~A?config=~A\">
 
     (let ((mathjax-header 
 	   (concatenate 'string
-			(format nil *mathjax-config-header* mathjax-config)
+			(if mathjax-config (format nil *mathjax-config-header* mathjax-config) "")
 			(if config
 			    (format nil *mathjax-load-header-with-config* mathjax-url config)
 			    (format nil *mathjax-load-header-no-config* mathjax-url)))))


### PR DESCRIPTION
Added some configuration options to the mathjax plugin.   They are documented in the plugin-use.md documentation. 

The defaults are as they used to be, but personally I think it would be cleaner if 
it least the default of mathjax-config is changed to NIL.

Also, feel free to suggest better names for the options.  Or if you have any other feedback.

Kind regards,
Wim Oudshoorn.
