### PR TITLE
Tiny improvement, do not emit text/x-math-config script section if not n...

### DIFF
--- a/plugins/mathjax.lisp
+++ b/plugins/mathjax.lisp
@@ -9,9 +9,9 @@
 
 (in-package :coleslaw-mathjax)
 
-(defvar *mathjax-header* "<script type=\"text/x-mathjax-config\">
-  MathJax.Hub.Config({~@[~A~]});
-</script>
+(defvar *mathjax-header* "~@[<script type=\"text/x-mathjax-config\">
+  MathJax.Hub.Config({~A});
+</script>~]
 <script type=\"text/javascript\" src=\"~A~@[?config=~A~]\"></script>")
 
 (defun enable (&key force config (preset "TeX-AMS-MML_HTMLorMML")


### PR DESCRIPTION
Thank you for including the changes and the cleanup.  
After looking at your changes there was one small obvious change I saw,
moving the conditional ~@[ ... ] include of the `config` to be outside the whole <script> thing.   

This has the effect that if no `config` is specified, the whole script section will be omitted.

Kind regards,
Wim Oudshoorn.
