### PR TITLE
Added <base> tag to make relative links work

### DIFF
--- a/themes/hyde/base.tmpl
+++ b/themes/hyde/base.tmpl
@@ -6,6 +6,7 @@
   <head>
     <title>{$config.title}</title>
     <meta http-equiv="content-type" content="application/xhtml+xml; charset=UTF-8" />
+    <base href="{$config.domain}/">
     <link href="http://fonts.googleapis.com/css?family=Vollkorn:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css" />
     <link href="http://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" type="text/css" />
     <link href= "{$config.domain}/css/style.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
This is the fix that works for me, and in some way I think this is correct.  
- Every link which is generated by the templates can put in the correct link itself
- All links generated by markdown or Rst etc. have a stable point to reference.

But if you find another fix or a better one, by all means use that.
This is just to show how it can work.

Wim Oudshoorn.
