### PR TITLE
Raise condition if the theme package cannot be found.

### DIFF
--- a/src/themes.lisp
+++ b/src/themes.lisp
@@ -22,9 +22,17 @@ any return value other than nil indicates the injection should be added."
     (list :head (injections-for :head)
           :body (injections-for :body))))
 
+(define-condition theme-does-not-exist-error (error)
+  ((theme :initarg :theme :reader theme))
+  (:report (lambda (c stream)
+	     (format stream "THEME-DOES-NOT-EXIST-ERROR cannot find theme: '~A'" (theme c)))))
+
 (defun theme-package (name)
-  "Find the package matching the theme NAME."
-  (find-package (string-upcase (concatenate 'string "coleslaw.theme." name))))
+  "Find the package matching the theme NAME.  
+It will signal an error when it cannot find the package for the theme."
+  (or (find-package (string-upcase (concatenate 'string "coleslaw.theme." name)))
+      (error 'theme-does-not-exist-error
+	     :theme name)))
 
 (defun theme-fn (name &optional (package (theme *config*)))
   "Find the symbol NAME inside PACKAGE which defaults to the theme package."


### PR DESCRIPTION
If you specify a theme that not exist, you get an error which is not very clear.
With this change a specify theme-does-not-exist condition is raised and 
the name of the missing theme is shown.

In the old code you get an error that the symbol 'base does not exist.
