### PR TITLE
Fix atom feed generation

### DIFF
--- a/src/feeds.lisp
+++ b/src/feeds.lisp
@@ -19,7 +19,7 @@
   "Render the default RSS and ATOM feeds along with any TAG-FEEDS."
   (let ((posts (by-date (find-all 'post))))
     (dolist (feed '((:path "rss.xml" :template :rss-feed)
-                    (:path "feed.atom" :template :atom-feed)))
+                    (:path "atom.xml" :template :atom-feed)))
       (apply #'render-feed posts feed))
     (dolist (feed tag-feeds)
       (apply #'render-feed posts (list :path (format nil "~A-rss.xml" feed)

--- a/themes/atom.tmpl
+++ b/themes/atom.tmpl
@@ -22,7 +22,7 @@
       <name>{$config.author}</name>
       <uri>{$config.domain}</uri>
     </author>
-    <content type="html">{$post.text |noAutoescape}</content>
+    <content type="html">{$post.text |escapeHtml}</content>
   </entry>
   {/foreach}
 


### PR DESCRIPTION
1. Put escaped HTML in `content`, following the [Atom Syndication Format standard](http://tools.ietf.org/html/rfc4287#section-3.1.1.2)
2. Generate `atom.xml` instead of `feed.atom`, as linked to in the generated feed
