### PR TITLE
Changed timestamp format of the sitemap so google does not complain (and...

### DIFF
--- a/plugins/sitemap.lisp
+++ b/plugins/sitemap.lisp
@@ -10,18 +10,22 @@
                 #:staging-dir
                 #:theme-fn
                 #:write-page)
+  (:import-from :local-time
+		#:format-timestring
+		#:now)
   (:export #:enable))
 
 (in-package :coleslaw-sitemap)
 
 (defmethod deploy :before (staging)
   "Render sitemap.xml under document root"
+  (declare (ignore staging))
   (let ((urls (append '("" "sitemap.xml") ; empty string is for root url
                       (mapcar #'page-url (find-all 'coleslaw:post)))))
     (write-page (rel-path (staging-dir *config*) "sitemap.xml")
                 (funcall (theme-fn 'sitemap "feeds")
                          (list :config *config*
                                :urls urls
-                               :pubdate (make-pubdate))))))
+                               :pubdate (format-timestring nil (now)))))))
 
 (defun enable ())


### PR DESCRIPTION
I noticed that the site map plugin does not create a fully compliant site map (at least according to google.)  The date time format is not correct.  
So this is a small fix.
