### PR TITLE
make output from restructured text generator useable

### DIFF
--- a/plugins/rst.lisp
+++ b/plugins/rst.lisp
@@ -4,14 +4,20 @@
 (defpackage :coleslaw-rst
   (:use :cl)
   (:import-from :coleslaw #:render-content)
-  (:import-from :docutils #:read-rst
-                          #:write-html)
+  (:import-from :docutils #:read-rst #:write-part #:register-settings-spec
+                          #:visit-node #:write-document)
+  (:import-from :docutils.writer.html #:html-writer #:write-part)
   (:export #:enable))
 
 (in-package :coleslaw-rst)
 
 (defmethod render-content (text (format (eql :rst)))
+  (register-settings-spec '((:generator nil)
+                            (:datestamp nil)))
   (with-output-to-string (str)
-    (write-html str (read-rst text))))
+    (let ((writer (make-instance 'html-writer))
+          (document (read-rst text)))
+      (visit-node writer document)
+      (write-document writer document str))))
 
 (defun enable ())


### PR DESCRIPTION
remove generator information from restructured text output plugin. 
