### PR TITLE
replace deprecated sb-ext:quit with sb-ext:exit

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -60,7 +60,7 @@ an UNWIND-PROTECT, then change back to the current directory."
 
 (defun exit ()
   "Exit the lisp system returning a 0 status code."
-  #+sbcl (sb-ext:quit)
+  #+sbcl (sb-ext:exit)
   #+ccl (ccl:quit)
   #+ecl (si:quit)
   #+cmucl (ext:quit)


### PR DESCRIPTION
As of [1.0.57](http://sbcl.org/all-news.html#1.0.57)
