### PR TITLE
Verify that parse-field returns an array.

### DIFF
--- a/src/content.lisp
+++ b/src/content.lisp
@@ -59,6 +59,7 @@
         (error "The provided file lacks the expected header."))
       (let ((meta (loop for line = (read-line in nil)
                      until (string= line (separator *config*))
+                     when (parse-field line)
                      appending (list (field-name line)
                                      (aref (parse-field line) 0))))
             (filepath (enough-namestring file (repo *config*)))


### PR DESCRIPTION
Oi, If the headers are empty read-content signals a Type-Error (Value nil is not of type Array). If an empty header is to be allowed read-content shouldn't be able to handle it, which is what this patch does. If its not to be allowed the proper condition should be signaled.
