### PR TITLE
Fix validation errors.

### DIFF
--- a/themes/hyde/base.tmpl
+++ b/themes/hyde/base.tmpl
@@ -43,8 +43,8 @@
         </a>
       {/if}
       by {$config.author}
-      <a rel="coleslaw" href="https://github.com/redline6561/coleslaw">
-        <img align="right" src="{$config.domain}/css/logo_small.jpg" />
+      <a id="coleslaw-logo" href="https://github.com/redline6561/coleslaw">
+        <img src="{$config.domain}/css/logo_small.jpg" alt="Coleslaw logo" />
       </a>
     </div>
   </body>

--- a/themes/hyde/css/style.css
+++ b/themes/hyde/css/style.css
@@ -1,5 +1,6 @@
 #content { background: #fff; padding-top: 1em }
 #header { float: right; margin-left: 1em; margin-bottom: 1em }
+#coleslaw-logo { float: right; }
 a { text-decoration: none; color: #992900 }
 a.anchor { color: black }
 .date { font-style: italic }

--- a/themes/readable/base.tmpl
+++ b/themes/readable/base.tmpl
@@ -56,8 +56,8 @@
               </a>
             {/if}
             by {$config.author}
-            <a rel="coleslaw" href="https://github.com/redline6561/coleslaw">
-              <img align="right" src="{$config.domain}/img/logo_small.jpg" /></p>
+            <a id="coleslaw-logo" href="https://github.com/redline6561/coleslaw">
+              <img src="{$config.domain}/img/logo_small.jpg" alt="Coleslaw logo" /></p>
             </a>
           </div>
         </div>

--- a/themes/readable/css/custom.css
+++ b/themes/readable/css/custom.css
@@ -1,3 +1,4 @@
+#coleslaw-logo { float: right; }
 hr {
     border: 0;
     height: 1px;


### PR DESCRIPTION
This is minor stuff to fix validation errors (against HTML5); I used http://html5.validator.nu/ to check and the changes seemed reasonable enough to me to include:
- The `rel` with value `"coleslaw"` is invalid and it seems something like `"made"` is no better. To identify the element `id` can be used, which also fixes
- the issue that `align` shouldn't be used in favour of CSS;
- and images need to have an `alt` attribute.

Cheers,
Olof
