### PR TITLE
optional 'since' handling in WP import plugin

### DIFF
--- a/plugins/import.lisp
+++ b/plugins/import.lisp
@@ -58,7 +58,8 @@
     (ensure-directories-exist (or output (repo *config*)))
     (let* ((xml (cxml:parse-file filepath (cxml-dom:make-dom-builder)))
            (posts (dom:get-elements-by-tag-name xml "item")))
-      (loop for post across posts do (import-post post output since))
+      (loop for post across posts do (if since (import-post post output since)
+                                         (import-post post output)))
       (delete-file filepath))))
 
 (defun enable (&key filepath output)


### PR DESCRIPTION
adds a conditional to the invocation of import-post in import-posts loop

there needs to be a guard around 'since' in the loop:
if import posts tries to pass it's optional 'since' parameter through to
import-post it will prevent any posts from being output , because every
post will be compared against a timestamp of nil
