### PR TITLE
conent.lisp (parse-medatada): add filename to the error message

### DIFF
--- a/src/content.lisp
+++ b/src/content.lisp
@@ -60,7 +60,7 @@
   (flet ((get-next-line (input)
            (string-trim '(#\Space #\Newline #\Tab) (read-line input nil))))
     (unless (string= (get-next-line stream) (separator *config*))
-      (error "The file lacks the expected header: ~a" (separator *config*)))
+      (error "The file, ~a, lacks the expected header: ~a" (file-namestring stream) (separator *config*)))
     (loop for line = (get-next-line stream)
        until (string= line (separator *config*))
        appending (parse-initarg line))))


### PR DESCRIPTION
Title says it all. Also Just in case, even though file-namestring expects a pathname not a stream it is ok to use [streams that where opened with open or with-open-file](http://www.lispworks.com/documentation/HyperSpec/Issues/iss261_w.htm])
