### PR TITLE
Don't compile plugin files.

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -53,7 +53,11 @@
          (plugin-package (sym)
            (format nil "~:@(coleslaw-~A~)" sym)))
     (let ((file (plugin-path name)))
-      (load (compile-file file :verbose nil :print nil) :verbose t))
+      (multiple-value-bind (output-file error)
+          (ignore-errors (compile-file file :verbose nil :print nil))
+        (when error
+          (warn "Error while compiling plugin ~A: ~A.~%" name error))
+        (load (or output-file file) :verbose t)))
     (let ((package (find-package (plugin-package name))))
       (apply (find-symbol "ENABLE" package) args))))
 


### PR DESCRIPTION
I've complained about this, so this is my fix I'm using on my machine. This prevents errors if the compilation is trying to write to a global, readable-only directory.
