### PR TITLE
find-all matching adjusted

### DIFF
--- a/plugins/incremental.lisp
+++ b/plugins/incremental.lisp
@@ -59,14 +59,11 @@
   (:method :around (status path &key)
     (let ((extension (pathname-type path))
           (ctypes (all-subclasses (find-class 'content))))
-      ;; This feels way too clever. I wish I could think of a better option.
-      (flet ((class-name-p (x class)
-               (string-equal x (symbol-name (class-name class)))))
-        ;; If the updated file's extension doesn't match one of our content types,
-        ;; we don't need to mess with it at all. Otherwise, since the class is
-        ;; annoyingly tricky to determine, pass it along.
-        (when-let (ctype (find extension ctypes :test #'class-name-p))
-          (call-next-method status path :ctype ctype))))))
+      ;; If the updated file's extension doesn't match one of our content types,
+      ;; we don't need to mess with it at all. Otherwise, since the class is
+      ;; annoyingly tricky to determine, pass it along.
+      (when-let (ctype (find extension ctypes :test #'class-name-p))
+        (call-next-method status path :ctype ctype)))))
 
 (defmethod process-change ((status (eql :deleted)) path &key)
   (let ((old (find-content-by-path path)))

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -68,12 +68,14 @@ use it as the template passing any RENDER-ARGS."
         (url (namestring (page-url document))))
     (write-file (rel-path (staging-dir *config*) url) html)))
 
-(defun find-all (doc-type)
+(defun find-all (doc-type &optional (matching (lambda (x) (typep x doc-type))))
   "Return a list of all instances of a given DOC-TYPE."
   (loop for val being the hash-values in *site*
-     when (typep val doc-type) collect val))
+     when (funcall matching val) collect val))
 
 (defun purge-all (doc-type)
   "Remove all instances of DOC-TYPE from memory."
-  (dolist (obj (find-all doc-type))
+  (dolist (obj (find-all doc-type
+                         (lambda (d) (equal (symbol-name (class-name (class-of d)))
+                                            (symbol-name doc-type)))))
     (remhash (page-url obj) *site*)))

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -68,10 +68,10 @@ use it as the template passing any RENDER-ARGS."
         (url (namestring (page-url document))))
     (write-file (rel-path (staging-dir *config*) url) html)))
 
-(defun find-all (doc-type &optional (matching (lambda (x) (typep x doc-type))))
+(defun find-all (doc-type &optional (matches-p (lambda (x) (typep x doc-type))))
   "Return a list of all instances of a given DOC-TYPE."
   (loop for val being the hash-values in *site*
-     when (funcall matching val) collect val))
+     when (funcall matches-p val) collect val))
 
 (defun purge-all (doc-type)
   "Remove all instances of DOC-TYPE from memory."

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -75,7 +75,8 @@ use it as the template passing any RENDER-ARGS."
 
 (defun purge-all (doc-type)
   "Remove all instances of DOC-TYPE from memory."
-  (dolist (obj (find-all doc-type
-                         (lambda (d) (equal (symbol-name (class-name (class-of d)))
-                                            (symbol-name doc-type)))))
-    (remhash (page-url obj) *site*)))
+  (flet ((matches-class-name-p (x)
+           (class-name-p (symbol-name doc-type)
+                         (class-of x))))
+    (dolist (obj (find-all doc-type #'matches-class-name-p))
+      (remhash (page-url obj) *site*))))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -98,3 +98,8 @@ in the git repo since REVISION."
            (cl-ppcre:split "\\s+" str)))
     (let ((cmd (format nil "git diff --name-status ~A HEAD" revision)))
       (mapcar #'split-on-whitespace (inferior-shell:run/lines cmd)))))
+
+(defun class-name-p (name class)
+  "True if the specified string is the name of the class provided"
+  ;; This feels way too clever. I wish I could think of a better option.
+  (string-equal name (symbol-name (class-name class))))


### PR DESCRIPTION
I want to be able to add differently rendered/themes post 'sub-types' to my blog ( linkblog entries, photo galleries, journal entries etc. ).
To this end, I'm experimenting with a plugin that allows me to subclass existing document types, to add additional properties/slots that can be handled conditionally.
I ran into a small snag, in as much as the current implementation of find-all is too greedy wrt matching on type of document.

The existing implementation of find-all implementation returns false positives for subclasses
I added a parameter of a predicate to implement matching, with a default value that preserves original behaviour

I then added an exact class matcher to purge-all invocation of find-all to stop it purging subclasses
