### PR TITLE
Introduce the theme-engine protocol

### DIFF
--- a/coleslaw.asd
+++ b/coleslaw.asd
@@ -23,6 +23,7 @@
                (:file "util")
                (:file "config")
                (:file "themes")
+               (:file "closure-template-engine")
                (:file "documents")
                (:file "content")
                (:file "posts")

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -51,8 +51,11 @@ User configs are allowed to specify a theme. A theme consists of a
 directory under "themes/" containing css, images, and at least
 3 templates: Base, Index, and Post.
 
-**Coleslaw** uses [cl-closure-template][closure_template]
-exclusively for templating. **cl-closure-template** is a well
+To allow the use of different templates for **Coleslaw** themes, **Coleslaw**
+provides a [Template engine API][template_api_docs].
+
+**Coleslaw** uses the [cl-closure-template][closure_template]
+template engine by default. **cl-closure-template** is a well
 documented CL implementation of Google's Closure Templates. Each
 template file should contain a namespace like
 `coleslaw.theme.theme-name`.
@@ -394,6 +397,7 @@ After pushing the branch to your fork, on github you should see a button to open
 
 [closure_template]: https://github.com/archimag/cl-closure-template
 [api_docs]: https://github.com/redline6561/coleslaw/blob/master/docs/plugin-api.md
+[template_api_docs]: https://github.com/kingcons/coleslaw/blob/master/docs/template-engine-api.md
 [clmd]: https://github.com/gwkkwg/cl-markdown
 [clrz]: https://github.com/redline6561/colorize
 [pyg]: http://pygments.org/

--- a/docs/template-engine-api.md
+++ b/docs/template-engine-api.md
@@ -1,0 +1,20 @@
+# Concepts
+
+* **Theme Function**: A function to be called for rendering content. A Theme
+  can provides multiple theme functions with different names. At a minimum 3
+  functions must be provided, `'base`, `'index` and `'post`.
+
+# Theme engine protocol
+
+- `get-theme-fn`: Retrieves the theme function by name from the template engine.
+- `compile-theme`: For themes need to be processed before used, **Coleslaw**
+  provides this generic function. It is guaranteed to be called before calling
+  `get-theme-fn`.
+- `template-engine`: Retrieves the current theme engine from a `blog`
+  instance. Mostly called with `*config*`, where the current `blog` instance,
+  as its argument.
+
+To implement a new template engine, one must define a method for at least
+`get-theme-fn` that specializes on the template engine's name and set the
+`template-engine` slot of the blog instance (in `*config*`) to the
+corresponding name on the `enable` function of your plugin.

--- a/plugins/sitemap.lisp
+++ b/plugins/sitemap.lisp
@@ -5,7 +5,8 @@
                           #:page-url
                           #:find-all
                           #:publish
-                          #:theme-fn
+                          #:get-theme-fn
+                          #:template-engine
                           #:add-document
                           #:write-document)
   (:import-from :alexandria #:hash-table-values)
@@ -25,6 +26,6 @@
   (let* ((base-urls '("" "sitemap.xml"))
          (urls (mapcar #'page-url (hash-table-values coleslaw::*site*)))
          (sitemap (make-instance 'sitemap :urls (append base-urls urls))))
-    (write-document sitemap (theme-fn 'sitemap "sitemap"))))
+    (write-document sitemap (get-theme-fn 'sitemap (template-engine *config*) "sitemap"))))
 
 (defun enable ())

--- a/plugins/static-pages.lisp
+++ b/plugins/static-pages.lisp
@@ -6,7 +6,8 @@
                           #:find-all
                           #:render
                           #:publish
-                          #:theme-fn
+                          #:get-theme-fn
+                          #:template-engine
                           #:render-text
                           #:write-document))
 
@@ -27,8 +28,9 @@
 (defmethod render ((object page) &key next prev)
   ;; For the time being, we'll re-use the normal post theme.
   (declare (ignore next prev))
-  (funcall (theme-fn 'post) (list :config *config*
-                                  :post object)))
+  (funcall (get-theme-fn 'post (template-engine *config*))
+           (list :config *config*
+                 :post object)))
 
 (defmethod publish ((doc-type (eql (find-class 'page))))
   (dolist (page (find-all 'page))

--- a/src/closure-template-engine.lisp
+++ b/src/closure-template-engine.lisp
@@ -1,0 +1,20 @@
+(in-package #:coleslaw)
+
+(defmethod compile-theme (theme (template-engine (eql :cl-closure)))
+  "Locate and compile the templates for the given THEME."
+  (do-files (file (find-theme theme) "tmpl")
+    (compile-template :common-lisp-backend file))
+  (do-files (file (app-path "themes/") "tmpl")
+    (compile-template :common-lisp-backend file)))
+
+(defun theme-package (name)
+  "Find the package matching the theme NAME or signal THEME-DOES-NOT-EXIST."
+  (or (find-package (format nil "~:@(coleslaw.theme.~A~)" name))
+      (error 'theme-does-not-exist :theme name)))
+
+(defun theme-fn (name &optional (package (theme *config*)))
+  "Find the symbol NAME inside PACKAGE which defaults to the theme package."
+  (find-symbol (princ-to-string name) (theme-package package)))
+
+(defmethod get-theme-fn (name (template-engine (eql :cl-closure)) &optional (package (theme *config*)))
+  (theme-fn name package))

--- a/src/coleslaw.lisp
+++ b/src/coleslaw.lisp
@@ -9,7 +9,7 @@ in REPO-DIR. Optionally, OLDREV is the revision prior to the last push."
   (load-config repo-dir)
   (setf *last-revision* oldrev)
   (load-content)
-  (compile-theme (theme *config*))
+  (compile-theme (theme *config*) (template-engine *config*))
   (let ((dir (staging-dir *config*)))
     (compile-blog dir)
     (deploy dir)))
@@ -55,7 +55,7 @@ in REPO-DIR. Optionally, OLDREV is the revision prior to the last push."
   (let ((current-working-directory (cl-fad:pathname-directory-pathname path)))
     (unless *config*
       (load-config (namestring current-working-directory))
-      (compile-theme (theme *config*)))
+      (compile-theme (theme *config*) (template-engine *config*)))
     (let* ((file (rel-path (repo-dir *config*) path))
            (content (construct content-type (read-content file))))
       (write-file "tmp.html" (render-page content)))))
@@ -63,7 +63,7 @@ in REPO-DIR. Optionally, OLDREV is the revision prior to the last push."
 (defun render-page (content &optional theme-fn &rest render-args)
   "Render the given CONTENT to HTML using THEME-FN if supplied.
 Additional args to render CONTENT can be passed via RENDER-ARGS."
-  (funcall (or theme-fn (theme-fn 'base))
+  (funcall (or theme-fn (get-theme-fn 'base (template-engine *config*)))
            (list :config *config*
                  :content content
                  :raw (apply 'render content render-args)

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,22 +1,23 @@
 (in-package :coleslaw)
 
 (defclass blog ()
-  ((author          :initarg :author         :reader author)
-   (charset         :initarg :charset        :reader charset)
-   (deploy-dir      :initarg :deploy-dir     :reader deploy-dir)
-   (domain          :initarg :domain         :reader domain)
-   (feeds           :initarg :feeds          :reader feeds)
-   (lang            :initarg :lang           :reader lang)
-   (license         :initarg :license        :reader license)
-   (page-ext        :initarg :page-ext       :reader page-ext)
-   (plugins         :initarg :plugins        :reader plugins)
-   (repo            :initarg :repo           :accessor repo-dir)
-   (routing         :initarg :routing        :reader routing)
-   (separator       :initarg :separator      :reader separator)
-   (sitenav         :initarg :sitenav        :reader sitenav)
-   (staging-dir     :initarg :staging-dir    :reader staging-dir)
-   (theme           :initarg :theme          :reader theme)
-   (title           :initarg :title          :reader title))
+  ((author          :initarg :author          :reader author)
+   (charset         :initarg :charset         :reader charset)
+   (deploy-dir      :initarg :deploy-dir      :reader deploy-dir)
+   (domain          :initarg :domain          :reader domain)
+   (feeds           :initarg :feeds           :reader feeds)
+   (lang            :initarg :lang            :reader lang)
+   (license         :initarg :license         :reader license)
+   (page-ext        :initarg :page-ext        :reader page-ext)
+   (plugins         :initarg :plugins         :reader plugins)
+   (repo            :initarg :repo            :accessor repo-dir)
+   (routing         :initarg :routing         :reader routing)
+   (separator       :initarg :separator       :reader separator)
+   (sitenav         :initarg :sitenav         :reader sitenav)
+   (staging-dir     :initarg :staging-dir     :reader staging-dir)
+   (theme           :initarg :theme           :reader theme)
+   (template-engine :initarg :template-engine :accessor template-engine)
+   (title           :initarg :title           :reader title))
   (:default-initargs
    :feeds        nil
    :license      nil
@@ -26,7 +27,8 @@
    :lang         "en"
    :page-ext     "html"
    :separator    ";;;;;"
-   :staging-dir  "/tmp/coleslaw"))
+   :staging-dir  "/tmp/coleslaw"
+   :template-engine :cl-closure))
 
 (defun dir-slot-reader (config name)
   "Take CONFIG and NAME, and return a directory pathname for the matching SLOT."

--- a/src/feeds.lisp
+++ b/src/feeds.lisp
@@ -16,7 +16,7 @@
 
 (defmethod publish ((doc-type (eql (find-class 'feed))))
   (dolist (feed (find-all 'feed))
-    (write-document feed (theme-fn (feed-format feed) "feeds"))))
+    (write-document feed (get-theme-fn (feed-format feed) (template-engine *config*) "feeds"))))
 
 ;;; Tag Feeds
 
@@ -34,4 +34,4 @@
 
 (defmethod publish ((doc-type (eql (find-class 'tag-feed))))
   (dolist (feed (find-all 'tag-feed))
-    (write-document feed (theme-fn (feed-format feed) "feeds"))))
+    (write-document feed (get-theme-fn (feed-format feed) (template-engine *config*) "feeds"))))

--- a/src/indexes.lisp
+++ b/src/indexes.lisp
@@ -16,12 +16,13 @@
     (setf url (compute-url object slug))))
 
 (defmethod render ((object index) &key prev next)
-  (funcall (theme-fn 'index) (list :tags (find-all 'tag-index)
-                                   :months (find-all 'month-index)
-                                   :config *config*
-                                   :index object
-                                   :prev prev
-                                   :next next)))
+  (funcall (get-theme-fn 'index (template-engine *config*))
+           (list :tags (find-all 'tag-index)
+                 :months (find-all 'month-index)
+                 :config *config*
+                 :index object
+                 :prev prev
+                 :next next)))
 
 ;;; Index by Tag
 

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -30,7 +30,9 @@
            #:author-of
            #:find-content-by-path
            ;; Theming + Plugin API
-           #:theme-fn
+           #:get-theme-fn
+           #:compile-theme
+           #:template-engine
            #:plugin-conf-error
            #:render-text
            #:add-injection

--- a/src/posts.lisp
+++ b/src/posts.lisp
@@ -14,10 +14,11 @@
           author (or author (author *config*)))))
 
 (defmethod render ((object post) &key prev next)
-  (funcall (theme-fn 'post) (list :config *config*
-                                  :post object
-                                  :prev prev
-                                  :next next)))
+  (funcall (get-theme-fn 'post (template-engine *config*))
+           (list :config *config*
+                 :post object
+                 :prev prev
+                 :next next)))
 
 (defmethod publish ((doc-type (eql (find-class 'post))))
   (loop for (next post prev) on (append '(nil) (by-date (find-all 'post)))

--- a/src/themes.lisp
+++ b/src/themes.lisp
@@ -21,15 +21,6 @@ function that takes a DOCUMENT and returns NIL or a STRING for template insertio
   (:report (lambda (c stream)
              (format stream "Cannot find the theme: '~A'" (theme c)))))
 
-(defun theme-package (name)
-  "Find the package matching the theme NAME or signal THEME-DOES-NOT-EXIST."
-  (or (find-package (format nil "~:@(coleslaw.theme.~A~)" name))
-      (error 'theme-does-not-exist :theme name)))
-
-(defun theme-fn (name &optional (package (theme *config*)))
-  "Find the symbol NAME inside PACKAGE which defaults to the theme package."
-  (find-symbol (princ-to-string name) (theme-package package)))
-
 (defun find-theme (theme)
   "Find the theme prefering themes in the local repo."
   (let ((local-theme (repo-path "themes/~a/" theme)))
@@ -37,9 +28,8 @@ function that takes a DOCUMENT and returns NIL or a STRING for template insertio
         local-theme
         (app-path "themes/~a/" theme))))
 
-(defun compile-theme (theme)
-  "Locate and compile the templates for the given THEME."
-  (do-files (file (find-theme theme) "tmpl")
-    (compile-template :common-lisp-backend file))
-  (do-files (file (app-path "themes/") "tmpl")
-    (compile-template :common-lisp-backend file)))
+(defgeneric get-theme-fn (name template-engine &optional package)
+  (:documentation "Return the theme function to be used by RENDER-PAGE."))
+
+(defgeneric compile-theme (theme template-engine)
+  (:documentation "Locate and compile the templates for the given THEME."))


### PR DESCRIPTION
The goal of this protocol is to allow users to customize what templates
their themes use. Introduce a new generic function GET-THEME-FN and make
COMPILE-THEME a generic function as well. Move all the cl-closure
template specific code to closure-template-engine

A thing I'm unsure of is if using keywords for template engines is good enough or if we should use the 'Class method' approach used by the document protocol? I'm inclined to go with the simpler approach for the time being.

@libre-man I would appreciate your feedback on the API, which is a subset of your PR. Is the documentation understandable? Do you think something is missing?

Note that I intend to merge against the 0.9.8 branch, The idea is to get your PR and #115 merged and do some light testing before merging on the master branch and release a new version of Coleslaw
