### PR TITLE
Added "drafts" feature

### DIFF
--- a/src/content.lisp
+++ b/src/content.lisp
@@ -54,7 +54,7 @@
    (tags :initarg :tags :reader content-tags)
    (version :initarg :version :reader content-version)   
    (text :initarg :text :reader content-text))
-  (:default-initargs :tags nil :date nil :version 'final))
+  (:default-initargs :tags nil :date nil :version "final"))
 
 (defmethod initialize-instance :after ((object content) &key)
   (with-slots (tags) object
@@ -94,8 +94,8 @@
 ;; Helper Functions
 
 (defun draft-p (obj)
-    "Test if the version of OBJ is set to DRAFT"
-    (eq (content-version obj) 'draft))
+  "Test if the version of OBJ is set to DRAFT"
+  (when (typep obj 'content) (search (content-version obj) "draft")))
 
 (defun tag-p (tag obj)
   "Test if OBJ is tagged with TAG."

--- a/src/content.lisp
+++ b/src/content.lisp
@@ -52,8 +52,9 @@
    (date :initarg :date :reader content-date)
    (file :initarg :file :reader content-file)
    (tags :initarg :tags :reader content-tags)
+   (version :initarg :version :reader content-version)   
    (text :initarg :text :reader content-text))
-  (:default-initargs :tags nil :date nil))
+  (:default-initargs :tags nil :date nil :version 'final))
 
 (defmethod initialize-instance :after ((object content) &key)
   (with-slots (tags) object
@@ -91,6 +92,10 @@
         (append metadata (list :text content :file filepath))))))
 
 ;; Helper Functions
+
+(defun draft-p (obj)
+    "Test if the version of OBJ is set to DRAFT"
+    (eq (content-version obj) 'draft))
 
 (defun tag-p (tag obj)
   "Test if OBJ is tagged with TAG."

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -68,10 +68,11 @@ use it as the template passing any RENDER-ARGS."
         (url (namestring (page-url document))))
     (write-file (rel-path (staging-dir *config*) url) html)))
 
-(defun find-all (doc-type)
+(defun find-all (doc-type &optional (include-drafts NIL))
   "Return a list of all instances of a given DOC-TYPE."
   (loop for val being the hash-values in *site*
-     when (typep val doc-type) collect val))
+    when (and (typep val doc-type) (or include-drafts (not (draft-p val))))
+	collect val))
 
 (defun purge-all (doc-type)
   "Remove all instances of DOC-TYPE from memory."

--- a/src/posts.lisp
+++ b/src/posts.lisp
@@ -27,5 +27,5 @@
                                   :next next)))
 
 (defmethod publish ((doc-type (eql (find-class 'post))))
-  (loop for (next post prev) on (append '(nil) (by-date (find-all 'post)))
+  (loop for (next post prev) on (append '(nil) (by-date (find-all 'post T)))
      while post do (write-document post nil :prev prev :next next)))


### PR DESCRIPTION
When I am writing a post, I like to preview the actual HTML being generated in my browser; so I will frequently build and deploy during the writing process. However, I am not particularly keen on having half-finished posts showing up on my blog homepage.

This pull request adds a feature to circumvent this problem. It introduces the metadata category `version`, defaulting to "final". If the version contains the string "draft", the relevant content is built and deployed, but will not show up on any index or feed. (It is thus only available via the direct URL.)