### PR TITLE
 Rsync bugfix, extensibility for: backups, rsync without a password, …

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,5 +32,6 @@ There are also many *optional* config parameters such as:
 * `:separator`     => to set the separator for content metadata, default: ";;;;;"
 * `:sitenav`       => to provide relevant links and ease navigation
 * `:staging-dir`   => for Coleslaw to do intermediate work, default: "/tmp/coleslaw"
-
+* `:rsync-options` => for additional options to send rsync via command line for
+  upload. Default "--delete -avz".
 [plugin-use]: https://github.com/redline6561/coleslaw/blob/master/docs/plugin-use.md

--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -225,7 +225,6 @@ stagedir/**
 **Example**: `(git-versioned stage commit upload)` or `(git-versioned stage commit)`
 
 ### Double Versioned
->>>>>>> equwal/master
 
 **Description**: Originally, this was Coleslaw's only deploy behavior.
   Instead of deploying directly to `:deploy-dir`, creates `.curr` and
@@ -242,7 +241,7 @@ stagedir/**
 folder every time the server is pushed. Could be expensive.
 
 **Example**: `(hard-versioning "~/backups")`
-=======
+
 ### Hard Versioned
 
 **Description**: Makes a full backup of the server directory into a backup
@@ -250,7 +249,6 @@ folder every time the server is pushed. Space-expensive, so makes bzip2
 archives, labeled with the clock's universal time.
 
 **Example**: `(hard-versioned "/home/user/backups")`
->>>>>>> equwal/master
 
 ## Wordpress Importer
 

--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -181,7 +181,51 @@ CL-USER> (chirp:complete-authentication "4173325")
 
 **Example**: `(twitter-summary-card :twitter-handle "@redline6561")
 
-## Versioned Deploys
+## Versioning Deploys
+
+<<<<<<< HEAD
+Either [automatic git interaction](#git-versioning),
+[double versioning](#double-versioning), or [hard versioning](#hard-versioning).
+
+### Git Versioning
+
+**Description**: Automatically stages, commits, and/or pushes the server's
+sources. Assumes that a git repository exists in the server's directory. Pushing
+is optional.
+
+**Example**: `(git-versioning 'stage 'commit 'push)` or `(git-versioning 'stage 'commit)`
+
+### Double Versioning
+=======
+Either [automatic git interaction](#git-versioned),
+[double versioned](#double-versioned), or [hard versioned](#hard-versioned).
+
+### Git Versioned
+
+**Description**: Automatically stages, commits, and/or pushes the server's
+sources. Assumes that a git repository exists in the server's staging
+directory. Pushing is optional. For maximum version control, put the staging
+directory below the source files, like this arrangement:
+
+```sh
+sitedir:
+.coleslawrc
+git
+.gitignore
+...
+
+sitedir/stagedir:
+...
+```
+Git can be too slow though, so making sure to only update the *source* files
+(and not the deployed html) can save a lot of time. Add this to your .gitignore:
+
+stagedir/**
+
+**Example**: `(git-versioned stage commit upload)` or `(git-versioned stage commit)`
+
+### Double Versioned
+>>>>>>> equwal/master
 
 **Description**: Originally, this was Coleslaw's only deploy behavior.
   Instead of deploying directly to `:deploy-dir`, creates `.curr` and
@@ -190,6 +234,23 @@ CL-USER> (chirp:complete-authentication "4173325")
   last two are automatically cleaned up.
 
 **Example**: `(versioned)`
+
+<<<<<<< HEAD
+### Hard Versioning
+
+**Description**: Makes a full backup of the server directory into a backup
+folder every time the server is pushed. Could be expensive.
+
+**Example**: `(hard-versioning "~/backups")`
+=======
+### Hard Versioned
+
+**Description**: Makes a full backup of the server directory into a backup
+folder every time the server is pushed. Space-expensive, so makes bzip2
+archives, labeled with the clock's universal time.
+
+**Example**: `(hard-versioned "/home/user/backups")`
+>>>>>>> equwal/master
 
 ## Wordpress Importer
 

--- a/examples/dump_db.sh
+++ b/examples/dump_db.sh
@@ -2,8 +2,17 @@
 
 LISP=sbcl
 
-## Disclaimer:
-## I have not tested that all lisps take the "--load" flag.
-## This code might spontaneously combust your whole everything.
-
-$LISP --load "dump-db.lisp"
+### DON'T EDIT BELOW THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING. ###
+DUMP="dump-db.lisp"
+if [ "$LISP"="cmucl" ] || [ "$LISP"="lispworks" ] || [ "$LISP"="gcl" ] || [ "$LISP"="abcl" ];
+then $LISP -load $DUMP
+else
+    if [ "$LISP"="clisp" ];
+    then $LISP -i $DUMP
+    else
+	if [ "$LISP"="allegro" ];
+	then $LISP -l $DUMP
+	else $LISP --load $DUMP #SBCL CCL ECL
+	fi
+    fi
+fi

--- a/plugins/git-versioned.lisp
+++ b/plugins/git-versioned.lisp
@@ -1,0 +1,33 @@
+(defpackage :coleslaw-git-versioned
+  (:use :cl)
+  (:import-from :coleslaw
+                #:*config*
+                #:run-lines)
+  (:import-from :uiop #:ensure-directory-pathname))
+(in-package :coleslaw-git-versioned)
+
+(defun git-versioned ())
+(defun enable (&rest commands)
+  (setf (symbol-function 'git-versioned)
+        (lambda ()
+          "Run all git commands as specified in the .coleslawrc."
+          (mapc #'funcall
+                (loop for fsym in commands
+                      collect (symbol-function (intern (symbol-name fsym)
+                                                       :coleslaw-git-versioned)))))))
+
+(defun command (args) (declare (ignore args)))
+(defmethod coleslaw:deploy :before (staging)
+  (setf (symbol-function 'command)
+        (lambda (args)
+          "Automatically git commit and push the blog to remote."
+          (run-lines staging
+                     (format nil "git ~A" args))))
+  (git-versioned))
+
+(defun stage ()
+  (command "stage -A"))
+(defun commit (&optional (commit-message "Automatic commit."))
+  (command (format nil "commit -m '~A'" commit-message)))
+(defun upload ()
+  (command "push"))

--- a/plugins/hard-versioned.lisp
+++ b/plugins/hard-versioned.lisp
@@ -1,0 +1,19 @@
+(defpackage :coleslaw-hard-versioned
+  (:use :cl)
+  (:import-from :coleslaw
+                #:*config*
+                #:run-program)
+  (:import-from :uiop #:ensure-directory-pathname))
+(in-package :coleslaw-hard-versioned)
+
+(defun hard-versioned (staging) (declare (ignore staging)))
+(defun enable (backup-dir)
+  (setf (symbol-function 'hard-versioned)
+        (lambda (staging)
+          (run-program "tar -cjf \"~Asite-~S.tar.bz2\" \"~A\""
+                       (ensure-directory-pathname backup-dir)
+                       (get-universal-time)
+                       staging))))
+(defmethod coleslaw:deploy :before (staging)
+  (hard-versioned staging))
+

--- a/plugins/versioned.lisp
+++ b/plugins/versioned.lisp
@@ -28,7 +28,6 @@
   (let ((dest (rel-path (deploy-dir *config*)
                         *symlink-dir*
                         (get-universal-time))))
-    (rsync-ensure-directories-exist dest)
     (path-move staging dest)))
 
 (defmethod coleslaw:deploy :before (staging)

--- a/plugins/versioned.lisp
+++ b/plugins/versioned.lisp
@@ -1,24 +1,38 @@
 (defpackage :coleslaw-versioned
   (:use :cl)
   (:import-from :coleslaw #:*config*
-                          #:deploy-dir
-                          #:rel-path
-                          #:run-program
-                          #:update-symlink))
+                #:deploy-dir
+                #:rsync-ensure-directories-exist
+                #:staging-dir
+                #:rel-path
+                #:run-program
+                #:update-symlink
+                #:path-move)
+  (:import-from :uiop #:subpathname))
 
 (in-package :coleslaw-versioned)
 
-(defmethod coleslaw:deploy (staging)
-  (let* ((dest (deploy-dir *config*))
-         (new-build (rel-path dest "generated/~a" (get-universal-time)))
-         (prev (rel-path dest ".prev"))
-         (curr (rel-path dest ".curr")))
+(defparameter *symlink-dir* "generated/~a")
+(defun local (staging)
+  (let* ((new-build (rel-path staging *symlink-dir* (get-universal-time)))
+         (prev (rel-path staging ".prev"))
+         (curr (rel-path staging ".curr")))
     (ensure-directories-exist new-build)
-    (run-program "mv ~a ~a" staging new-build)
     (when (and (probe-file prev) (truename prev))
       (run-program "rm -r ~a" (truename prev)))
     (when (probe-file curr)
       (update-symlink prev (truename curr)))
     (update-symlink curr new-build)))
+
+(defun deploy (staging)
+  (let ((dest (rel-path (deploy-dir *config*)
+                        *symlink-dir*
+                        (get-universal-time))))
+    (rsync-ensure-directories-exist dest)
+    (path-move staging dest)))
+
+(defmethod coleslaw:deploy :before (staging)
+  (local staging)
+  (deploy staging))
 
 (defun enable ())

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -20,8 +20,7 @@
    (title           :initarg :title          :reader title)
    (index-ext       :initarg :index-ext      :reader index-ext)
    (conf-sitemap    :initarg :conf-sitemap   :reader conf-sitemap)
-   (rsync-passfile  :initarg :rsync-passfile :reader rsync-passfile)
-   (which-sshpass   :initarg :which-sshpass  :reader which-sshpass))
+   (rsync-options  :initarg :rsync-options :reader rsync-options))
   
   (:default-initargs
    :feeds        nil
@@ -29,8 +28,7 @@
    :conf-sitemap nil
    :plugins      nil
    :sitenav      nil
-   :rsync-passfile nil
-   :which-sshpass nil
+   :rsync-options "--delete -avz"
    :excerpt-sep  "<!--more-->"
    :name-fn      'identity
    :charset      "UTF-8"

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,5 +1,4 @@
 (in-package :coleslaw)
-
 (defclass blog ()
   ((author          :initarg :author         :reader author)
    (charset         :initarg :charset        :reader charset)
@@ -7,9 +6,10 @@
    (domain          :initarg :domain         :reader domain)
    (excerpt-sep     :initarg :excerpt-sep    :reader excerpt-sep)
    (feeds           :initarg :feeds          :reader feeds)
+   (name-fn         :initarg :name-fn        :reader name-fn)
    (lang            :initarg :lang           :reader lang)
    (license         :initarg :license        :reader license)
-   (page-ext        :initarg :page-ext       :reader page-ext)
+   (page-ext        :initarg :page-ext       :reader page-ext-intolerant)
    (plugins         :initarg :plugins        :reader plugins)
    (repo            :initarg :repo           :accessor repo-dir)
    (routing         :initarg :routing        :reader routing)
@@ -17,19 +17,35 @@
    (sitenav         :initarg :sitenav        :reader sitenav)
    (staging-dir     :initarg :staging-dir    :reader staging-dir)
    (theme           :initarg :theme          :reader theme)
-   (title           :initarg :title          :reader title))
+   (title           :initarg :title          :reader title)
+   (index-ext       :initarg :index-ext      :reader index-ext)
+   (conf-sitemap    :initarg :conf-sitemap   :reader conf-sitemap)
+   (rsync-passfile  :initarg :rsync-passfile :reader rsync-passfile)
+   (which-sshpass   :initarg :which-sshpass  :reader which-sshpass))
+  
   (:default-initargs
    :feeds        nil
    :license      nil
+   :conf-sitemap nil
    :plugins      nil
    :sitenav      nil
+   :rsync-passfile nil
+   :which-sshpass nil
    :excerpt-sep  "<!--more-->"
+   :name-fn      'identity
    :charset      "UTF-8"
    :lang         "en"
-   :page-ext     "html"
+   :page-ext     #1="html"
    :separator    ";;;;;"
-   :staging-dir  "/tmp/coleslaw"))
+   :staging-dir  "/tmp/coleslaw"
+   :index-ext    #1#))
 
+(defun page-ext (config)
+  "Get page extension, and allow for an extensionless system."
+  (let ((ext (page-ext-intolerant config)))
+    (if (string= ext "")
+        ""
+        (concatenate 'string "." ext))))
 (defun dir-slot-reader (config name)
   "Take CONFIG and NAME, and return a directory pathname for the matching SLOT."
   (ensure-directory-pathname (slot-value config name)))
@@ -89,3 +105,4 @@ preferred over the home directory if provided."
       (setf *config* (construct 'blog config-form)
             (repo-dir *config*) repo-dir)))
   (load-plugins (plugins *config*)))
+

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -42,7 +42,16 @@ is provided, it overrides the route used."
       (error "No routing method found for: ~A" class-name))
     (let* ((result (format nil route unique-id))
            (type (or (pathname-type result) (page-ext *config*))))
-      (make-pathname :type type :defaults result))))
+      (make-pathname :name (funcall (name-fn *config*)
+                                    (pathname-name result))
+                     :type (when (string/= type "")
+                             (if (or (string-equal "index"
+                                                   (pathname-name result))
+                                     (string-equal "1"
+                                                   (pathname-name result)))
+                                 (index-ext *config*)
+                                 type))
+                     :defaults result))))
 
 (defun get-route (doc-type)
   "Return the route format string for DOC-TYPE."

--- a/src/indexes.lisp
+++ b/src/indexes.lisp
@@ -9,7 +9,8 @@
   ((url     :initarg :url     :reader page-url)
    (name    :initarg :name    :reader index-name)
    (title   :initarg :title   :reader title-of)
-   (content :initarg :content :reader index-content)))
+   (content :initarg :content :reader index-content)
+   (image   :initarg :image   :reader image)))
 
 (defmethod initialize-instance :after ((object index) &key slug)
   (with-slots (url) object

--- a/src/posts.lisp
+++ b/src/posts.lisp
@@ -4,11 +4,12 @@
   ((title  :initarg :title  :reader title-of)
    (author :initarg :author :reader author-of)
    (excerpt :initarg :excerpt :reader excerpt-of)
-   (format :initarg :format :reader post-format))
-  (:default-initargs :author nil :excerpt nil))
+   (format :initarg :format :reader post-format)
+   (image :initarg :image :reader image-of))
+  (:default-initargs :author nil :excerpt nil :title nil :image nil))
 
 (defmethod initialize-instance :after ((object post) &key)
-  (with-slots (url title author excerpt format text) object
+  (with-slots (url title author excerpt format text image) object
     (let (post-content)
       (setf url (compute-url object (slugify title))
             format (make-keyword (string-upcase format))
@@ -18,7 +19,9 @@
                                       post-content
                                       :limit 2)))
             text post-content
+            image image
             author (or author (author *config*))))))
+
 
 (defmethod render ((object post) &key prev next)
   (funcall (theme-fn 'post) (list :config *config*

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -122,3 +122,40 @@ in the git repo since REVISION."
            (cl-ppcre:split "\\s+" str)))
     (let ((cmd (format nil "git diff --name-status ~A HEAD" revision)))
       (mapcar #'split-on-whitespace (inferior-shell:run/lines cmd)))))
+
+(defun rsync-installed-p (&optional (test-args "--version"))
+  (block escape
+    (handler-case (run-program "rsync ~A" test-args)
+      (t () (return-from escape nil)))
+    t))
+
+(defun run-lines (dir &rest programs)
+  "Runs some programs, in a directory."
+  (mapc (lambda (line)
+          (run-program "cd ~A && ~A" dir line))
+        programs))
+
+(defun run-rsync (fmt-args &rest args)
+  (run-program "rsync ~a ~a"
+               (if (and (rsync-passfile *config*)
+                        (which-sshpass *config*))
+                   "--rsh=\"/usr/bin/sshpass -f /home/jose/.backup-pass ssh -o StrictHostKeyChecking=no\""
+                   "")
+               (apply #'format nil fmt-args args)))
+
+(defun path-move (from to)
+  "Move things, or copy with rsync."
+  (if (rsync-installed-p)
+      (run-rsync "--delete -lavz ~a ~a"
+                 from
+                 to)
+      (run-program "mv ~a ~a" from to)))
+
+(defun update-symlink (path target)
+  (run-program "ln -sfn ~a ~a" target path))
+
+(defun rsync-ensure-directories-exist (path)
+  "Ensure directories exist, but not if using rsync."
+  (when (not (rsync-installed-p))
+    (ensure-directories-exist path)))
+

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -135,27 +135,25 @@ in the git repo since REVISION."
           (run-program "cd ~A && ~A" dir line))
         programs))
 
-(defun run-rsync (fmt-args &rest args)
-  (run-program "rsync ~a ~a"
-               (if (and (rsync-passfile *config*)
-                        (which-sshpass *config*))
-                   "--rsh=\"/usr/bin/sshpass -f /home/jose/.backup-pass ssh -o StrictHostKeyChecking=no\""
-                   "")
-               (apply #'format nil fmt-args args)))
+(defun ensure-remote-directories-exist (rsync-path)
+  "Not implemented."
+  rsync-path)
+(defun run-rsync (from to)
+  "Execute an rsync command, keeping with rsync options config."
+  (run-program "rsync ~a ~a ~a"
+               (rsync-options *config*)
+               (ensure-directories-exist from)
+               (ensure-remote-directories-exist to)))
 
 (defun path-move (from to)
   "Move things, or copy with rsync."
   (if (rsync-installed-p)
-      (run-rsync "--delete -lavz ~a ~a"
-                 from
-                 to)
-      (run-program "mv ~a ~a" from to)))
+      (run-rsync from to)
+      (run-program "mv ~a ~a"
+                   (ensure-directories-exist from)
+                   (ensure-directories-exist to))))
 
 (defun update-symlink (path target)
   (run-program "ln -sfn ~a ~a" target path))
 
-(defun rsync-ensure-directories-exist (path)
-  "Ensure directories exist, but not if using rsync."
-  (when (not (rsync-installed-p))
-    (ensure-directories-exist path)))
 


### PR DESCRIPTION
…url generation, images in sitenav.

# Bugfixes
## Rsync recursive directories fix
The old version didn't properly ensure that directories end in a slash, so rsync
would do the wrong thing and make an additional level to the directory tree each
time the site was pushed.
## Other lisp support
I read through the docs for some non-sbcl lisps, and edited the bash file to
call them according to the docs. I didn't test them (except SBCL, which is the
same), but some of them might work now where they exploded before.
## Symlink `(versioned)` no longer breaks deployment
The problem was that the `deploy` method was overwritten rather than executed
before the default. Specifying the order with `(defmethod coleslaw:deploy
:BEFORE...)` makes it advice to the original instead.

# Rsync custom options
Users may need custom RSYNC command options, see https://github.com/kingcons/coleslaw/issues/150 and https://github.com/kingcons/coleslaw/issues/162
I use coleslaw on my laptop to then push with the :deploy-dir being my remote
server. I wanted to use a special rsync command that uses sshpass and a password
file to avoid needing a password for upload. Now the options are in the config
(I probably should have made it a plugin, but it only activates if both
`:rsync-passfile` and `:which-sshpass` are defined).

# Extensibility
## Control of URL generation
### page extensions
I wanted posts to have no extension (via `:page-ext`), so I had to modify the
code to allow for `:page-ext ""` to work, and without inserting a dot at the end
of my files.
### index extensions
Doing the edits to page-ext broke my index symlink, so I had to add
`:index-ext` to the config.
### name-fn, calling a function on the title
The default way for coleslaw to generate the post URL is to just use the title,
inserting dashes for spaces. I wanted lowercase URLs though, so I made
`:name-fn` in the config to define a function like `:name-fn string-downcase`
for making the URLs. The default is `identity`, so it won't change your old
URLs.
### Image format
Added support for themes that need images in the sitenav (via .coleslawrc).

# More Versioning Options

The default `(versioned)` doesn't do enough for me. I want longer-term backups,
and I wanted to backup the sources as well as the HTML. For a while I just wrote
a custom `main` function that copied my whole source and staging directories
(now the `(hard-versioned "/backup/dir/here")` plugin). Then I decided to use
git, but staging the sources *and* the HTML took too long to diff, so I ended up
putting the staging dir in my .gitignore. It also (optionally) automatically
pushes the automatic commit, working as a full-on remote backup solution. You
can use all three at once, or any combination of them. There is some support
already for this, but not if I want to have coleslaw installed locally (instead
of on the server).

# Todo:
* Better reporting of rsync errors
* Generate the remote directory tree automatically via rsync, instead of blowing
  up without a helpful error when a file does not exist (currently this bug does
  not show up if coleslaw is running on a local server, it just needs to be
  resolved for remote deployment).
* It doesn't really make sense to allow users to use `(versioned)`,
  `(hard-versioned)`, and `(git-versioned...)`. It would be better to allow all
  three but have some user control on deployment. Since git can take awhile on a large site,
  (defun main (dir &optional (backup :safe)))
  `(main "/path/to/blog" :fastest)` for no backup
  `(main "/path/to/blog" :fast)` for hardcopy
  `(main "/path/to/blog" :fast!)` for symlink
  `(main "/path/to/blog" :safe)` for git
(or a similar setup) would make sense. For now I just edit my conf to change.
* For hardlink backups, it would make sense to allow specification of a
  rotation/deletion mechanism, like what
  [rsnapshot uses](https://wiki.archlinux.org/index.php/Rsnapshot#Retain_Previous_Backups).
* Ensure remote directories for rsync (I installed an identity function, to be filled in at some point)