### PR TITLE
Add mailing list from common-lisp.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 Coleslaw is Flexible Lisp Blogware similar to [Frog](https://github.com/greghendershott/frog), [Jekyll](http://jekyllrb.com/), or [Hakyll](http://jaspervdj.be/hakyll/).
 
-Have questions? Come talk to us on IRC in **#coleslaw** on Freenode!
+Have questions? 
+- IRC in **#coleslaw** on Freenode!
+- Subscribe to the mailing list [**coleslaw@common-lisp.net**](https://mailman.common-lisp.net/listinfo/coleslaw).
 
 ## Features
 


### PR DESCRIPTION
common-lisp.net has graciously made a mailing list for coleslaw (at my request, by snail mail). I'd be happy to hand out permissions to the current maintainers of Coleslaw. Currently it is just me; hopefully this is okay.

coleslaw@common-lisp.net
https://mailman.common-lisp.net/listinfo/coleslaw