### PR TITLE
Markless plugin through cl-markless-plump

### DIFF
--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -102,6 +102,17 @@ post with `format: cl-who` and the plugin will do the rest.
 - `:config` is used as supplementary inline configuration to the
   `MathJax.Hub.Config ({ ... });`. It is unused by default.
 
+## Markless
+
+**Description**: [Markless](https://shirakumo.github.io/markless) is a
+  new document markup standard. To use it in your posts, create the
+  posts with `format: mess`. The output is generated using
+  [cl-markless-plump](https://shirakumo.github.io/cl-markless/cl-markless-plump/),
+  meaning any syntax extensions that work with it should also be
+  available in Coleslaw.
+
+**Example**: `(mess)`
+
 ## ReStructuredText
 
 **Description**: Some people really like

--- a/plugins/markless.lisp
+++ b/plugins/markless.lisp
@@ -1,0 +1,12 @@
+(eval-when (:compile-toplevel :load-toplevel)
+  (ql:quickload 'cl-markless-plump))
+
+(defpackage #:coleslaw-markless
+  (:use #:cl)
+  (:export #:enable))
+(in-package :coleslaw-markless)
+
+(defmethod render-text (text (format (eql :mess)))
+  (cl-markless:output text :target NIL :format 'cl-markless-plump:plump))
+
+(defun enable ())


### PR DESCRIPTION
This plugin allows writing articles using the [Markless](https://shirakumo.github.io/markless) language.