### PR TITLE
Control of URL generation -- extensions and name-fn

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -25,9 +25,11 @@ There are also many *optional* config parameters such as:
 * `:charset`       => to set HTML attributes for international characters, default: "UTF-8"
 * `:feeds`         => to generate RSS and Atom feeds for certain tagged content
 * `:excerpt-sep`   => to set the separator for excerpt in content, default: `<!--more-->`
+* `:index-ext`     => The extension for the index, default "html" for index.html
 * `:lang`          => to set HTML attributes indicating the site language, default: "en"
 * `:license`       => to override the displayed content license, the default is CC-BY-SA
-* `:page-ext`      => to set the suffix of generated files, default: "html"
+* `:name-fn`       => to modify URL strings after they are generated, default: `'identity`
+* `:page-ext`      => to set the suffix of generated files, default: "html". "" for no extension
 * `:plugins`       => to configure and enable coleslaw's [various plugins][plugin-use]
 * `:separator`     => to set the separator for content metadata, default: ";;;;;"
 * `:sitenav`       => to provide relevant links and ease navigation

--- a/src/coleslaw.lisp
+++ b/src/coleslaw.lisp
@@ -40,8 +40,8 @@
       (publish ctype))
     (do-subclasses (itype index)
       (publish itype))
-    (update-symlink (format nil "index.~A" (page-ext *config*))
-                    (format nil "1.~A" (page-ext *config*)))))
+    (update-symlink (format nil "index.~A" (index-ext *config*))
+                    (format nil "1~A" (page-ext *config*)))))
 
 (defgeneric deploy (staging)
   (:documentation "Deploy the STAGING build to the directory specified in the config.")

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -9,7 +9,7 @@
    (feeds           :initarg :feeds          :reader feeds)
    (lang            :initarg :lang           :reader lang)
    (license         :initarg :license        :reader license)
-   (page-ext        :initarg :page-ext       :reader page-ext)
+   (page-ext        :initarg :page-ext       :reader page-ext-intolerant)
    (plugins         :initarg :plugins        :reader plugins)
    (repo            :initarg :repo           :accessor repo-dir)
    (routing         :initarg :routing        :reader routing)
@@ -17,7 +17,8 @@
    (sitenav         :initarg :sitenav        :reader sitenav)
    (staging-dir     :initarg :staging-dir    :reader staging-dir)
    (theme           :initarg :theme          :reader theme)
-   (title           :initarg :title          :reader title))
+   (title           :initarg :title          :reader title)
+   (index-ext       :initarg :index-ext      :reader index-ext))
   (:default-initargs
    :feeds        nil
    :license      nil
@@ -26,10 +27,17 @@
    :excerpt-sep  "<!--more-->"
    :charset      "UTF-8"
    :lang         "en"
-   :page-ext     "html"
+   :page-ext     #1="html"
    :separator    ";;;;;"
-   :staging-dir  "/tmp/coleslaw"))
+   :staging-dir  "/tmp/coleslaw"
+   :index-ext    #1#))
 
+(defun page-ext (config)
+  "Get page extension, and allow for an extensionless system."
+  (let ((ext (page-ext-intolerant config)))
+    (if (string= ext "")
+        ""
+        (concatenate 'string "." ext))))
 (defun dir-slot-reader (config name)
   "Take CONFIG and NAME, and return a directory pathname for the matching SLOT."
   (ensure-directory-pathname (slot-value config name)))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -7,6 +7,7 @@
    (domain          :initarg :domain         :reader domain)
    (excerpt-sep     :initarg :excerpt-sep    :reader excerpt-sep)
    (feeds           :initarg :feeds          :reader feeds)
+   (name-fn         :initarg :name-fn        :reader name-fn)
    (lang            :initarg :lang           :reader lang)
    (license         :initarg :license        :reader license)
    (page-ext        :initarg :page-ext       :reader page-ext-intolerant)
@@ -25,6 +26,7 @@
    :plugins      '((rsync "-avz" "--delete" "--exclude" ".git/" "--exclude" ".gitignore" "--copy-links"))
    :sitenav      nil
    :excerpt-sep  "<!--more-->"
+   :name-fn      'identity
    :charset      "UTF-8"
    :lang         "en"
    :page-ext     #1="html"

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -42,7 +42,8 @@ is provided, it overrides the route used."
       (error "No routing method found for: ~A" class-name))
     (let* ((result (format nil route unique-id))
            (type (or (pathname-type result) (page-ext *config*))))
-      (make-pathname :name (pathname-name result)
+      (make-pathname :name (funcall (name-fn *config*)
+                                    (pathname-name result))
                      :type (when (string/= type "")
                              (if (or (string-equal "index"
                                                    (pathname-name result))

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -42,7 +42,15 @@ is provided, it overrides the route used."
       (error "No routing method found for: ~A" class-name))
     (let* ((result (format nil route unique-id))
            (type (or (pathname-type result) (page-ext *config*))))
-      (make-pathname :type type :defaults result))))
+      (make-pathname :name (pathname-name result)
+                     :type (when (string/= type "")
+                             (if (or (string-equal "index"
+                                                   (pathname-name result))
+                                     (string-equal "1"
+                                                   (pathname-name result)))
+                                 (index-ext *config*)
+                                 type))
+                     :defaults result))))
 
 (defun get-route (doc-type)
   "Return the route format string for DOC-TYPE."


### PR DESCRIPTION
Allow for fine-grained control of URL generation including file extensions and
name functions.

_page extensions_

I wanted posts to have no extension (via :page-ext), so I had to modify the
code to allow for :page-ext "" to work, and without inserting a dot at the end
of my files.

_index extensions_

Doing the edits to page-ext broke my index symlink, so I had to add
:index-ext to the config.

_name-fn, calling a function on the title_

The default way for coleslaw to generate the post URL is to just use the title,
inserting dashes for spaces. I wanted lowercase URLs though, so I made
:name-fn in the config to define a function like :name-fn string-downcase
for making the URLs. The default is identity, so it won't change your old
URLs.
