### PR TITLE
Git versioned plugin

### DIFF
--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -212,7 +212,24 @@ CL-USER> (chirp:complete-authentication "4173325")
 
 **Example**: `(twitter-summary-card :twitter-handle "@redline6561")
 
-## Versioned Deploys
+## Versioning Deploys
+
+Either [automatic git interaction](#git-versioned) or [double
+versioning](#double-versioning)
+
+### Git Versioned
+
+**Description**: Automatically stages, commits, and/or pushes the server's
+sources. Assumes that a git repository exists in the server's directory. Pushing
+is optional.
+
+**Examples**: 
+`(git-versioned "~/src/dir/" 'stage 'commit 'push)`
+
+
+`(git-versioned "~/src/dir/" 'stage 'commit)`
+
+### Double Versioning
 
 **Description**: Originally, this was Coleslaw's only deploy behavior.
   Instead of deploying directly to `:deploy-dir`, creates `.curr` and

--- a/plugins/git-versioned.lisp
+++ b/plugins/git-versioned.lisp
@@ -1,0 +1,46 @@
+(defpackage :coleslaw-git-versioned
+  (:use :cl)
+  (:import-from :coleslaw
+                #:*config*
+                #:run-lines)
+  (:import-from :uiop #:ensure-directory-pathname))
+
+(in-package :coleslaw-git-versioned)
+
+(defconstant +nothing-to-commit+ 1
+  "Error code when git-commit has nothing staged to commit.")
+
+;; These have their symbol-functions set in order to close over the src-dir
+;; variable.
+(defun git-versioned ()
+  "Run all git commands as specified in the .coleslawrc.")
+(defun command (args)
+  "Automatically git commit and push the blog to remote."
+  (declare (ignore args)))
+
+(defun enable (src-dir &rest commands)
+  "Define git-versioned functions at runtime."
+  (setf (symbol-function 'git-versioned)
+        (lambda ()
+          (loop for fsym in commands
+                do (funcall (symbol-function (intern (symbol-name fsym)
+                                                     :coleslaw-git-versioned))))))
+  (setf (symbol-function 'command)
+        (lambda (args)
+          (run-lines src-dir
+                     (format nil "git ~A" args)))))
+(defmethod coleslaw:deploy :before (staging)
+  (declare (ignore staging))
+  (git-versioned))
+
+(defun stage () (command "stage -A"))
+(defun commit (&optional (commit-message "Automatic commit."))
+  (handler-case (command (format nil "commit -m '~A'" commit-message))
+    (uiop/run-program:subprocess-error (error)
+      (case (uiop/run-program:subprocess-error-code error)
+        (+nothing-to-commit+ (format t "Nothing to commit. Error ~d"
+                                     +nothing-to-commit+))
+        (otherwise (error error))))))
+
+(defun upload ()
+  (command "push"))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -100,6 +100,12 @@ If ARGS is provided, use (fmt path args) as the value of PATH."
 use (fmt program args) as the value of PROGRAM."
   (inferior-shell:run (fmt program args) :show t))
 
+(defun run-lines (dir &rest programs)
+  "Runs some programs, in a directory."
+  (mapc (lambda (line)
+          (run-program "cd ~A && ~A" dir line))
+        programs))
+
 (defun take-up-to (n seq)
   "Take elements from SEQ until all elements or N have been taken."
   (subseq seq 0 (min (length seq) n)))


### PR DESCRIPTION
Fully automated git versioning upon static content deployment. This is a drop-in
replacement of the `versioned` plugin, which uses symlink cycling, and is
superior to it since it is just a git repo. This is different from a gh-pages
repo, in that it only assumes the free program `git` is available, and not the
proprietary platform github.com

It is also possible to store the staging directory inside of the source
directory, although this may result in slow commit times as git tries to deal
with version controlling the whole site.

`(git-versioned "~/path/to/src/dir" 'stage)`

`git-versioned` needs to know where the source is so it can run `git` commands
from that directory. Here all the commands implemented:

- `stage` runs `git stage -A`
- `commit` runs `git commit -m "Automatic commit."`
- `upload` runs `git push`

There currently isn't external support for custom commit messages at each
invocation. This could be helpful to add for some.

Some rudimentary error handling is provided for the case of there being nothing
to commit. Failure to push is left to be handled by the user.

Putting the coleslaw staging directory inside the git repository has the benefit
of version controlling the whole site with git. This can be a problem though for
large sites, especially with lots of binary data.
