### PR TITLE
Update google analytics integration: create gtag plugin

### DIFF
--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -19,7 +19,9 @@ The former default deployment method.
 **Description**: Provides traffic analysis through
   [Google Analytics](http://www.google.com/analytics/).
 
-**Example**: `(analytics :tracking-code "google-provided-unique-id")`
+**Example**: `(gtag :tracking-code "google-provided-unique-id")`
+
+**Note**: You can use `(analytics :tracking-code "google-provided-unique-id")` for the legacy integration with Google Analytics. 
 
 ## Analytics via Piwik
 

--- a/plugins/gtag.lisp
+++ b/plugins/gtag.lisp
@@ -1,0 +1,21 @@
+(defpackage :coleslaw-gtag
+  (:use :cl)
+  (:export #:enable)
+  (:import-from :coleslaw #:add-injection))
+
+(in-package :coleslaw-gtag)
+
+(defvar *analytics-js*
+"<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src='https://www.googletagmanager.com/gtag/js?id=~a'></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '~a');
+</script>")
+
+(defun enable (&key tracking-code)
+  (let ((snippet (format nil *analytics-js* tracking-code tracking-code)))
+    (add-injection (constantly snippet) :head)))


### PR DESCRIPTION
The new setup for google analytics recommends the following code snippet: 

![ezgif-6-f02dfb7ef77c](https://user-images.githubusercontent.com/28762146/109738002-0f2ec900-7b95-11eb-964e-06b5f1e3829b.png)

Thus, the new plugin uses that as the code to be injected. It is modeled after the current analytics plugin.