### PR TITLE
make sitemap subclass index, add to routing

### DIFF
--- a/cli/cli.lisp
+++ b/cli/cli.lisp
@@ -29,7 +29,8 @@
            (:month-index    \"date/~~a\")
            (:numeric-index  \"~~d\")
            (:feed           \"~~a.xml\")
-           (:tag-feed       \"tag/~~a.xml\"))
+           (:tag-feed       \"tag/~~a.xml\")
+           (:sitemap        \"~~a.xml\"))
  :title \"Improved Means for Achieving Deteriorated Ends\" ;; a site title
  :theme \"hyde\"                        ;; to select one of the themes in \"coleslaw/themes/\"
  

--- a/plugins/sitemap.lisp
+++ b/plugins/sitemap.lisp
@@ -13,7 +13,7 @@
 
 (in-package :coleslaw-sitemap)
 
-(defclass sitemap ()
+(defclass sitemap (index)
   ((urls :initarg :urls :reader urls)))
 
 (defmethod page-url ((object sitemap)) "sitemap.xml")


### PR DESCRIPTION
In this PR I fix the existing sitemap plugin. 

This fixes these two PRs:
- https://github.com/coleslaw-org/coleslaw/issues/142
- https://github.com/coleslaw-org/coleslaw/issues/84

As mentioned in this comment by @PuercoPop https://github.com/coleslaw-org/coleslaw/issues/142#issuecomment-335061002, the sitemap class is subclassing index. Additionally, the entry for the sitemap has to be added to routing in the config for the plugin to work.


https://user-images.githubusercontent.com/28762146/133953586-08b6464b-afff-4df2-a155-0c7a8aadb5e0.mov

