### PR TITLE
Add :oldrev key to call to coleslaw:main

### DIFF
--- a/examples/example.post-receive
+++ b/examples/example.post-receive
@@ -24,11 +24,11 @@ while read oldrev newrev refname; do
         echo -e "\n  Master updated. Running coleslaw...\n"
         if [ $LISP = sbcl ]; then
             sbcl --eval "(ql:quickload 'coleslaw)" \
-                 --eval "(coleslaw:main \"$TMP_GIT_CLONE\" \"$oldrev\")" \
+                 --eval "(coleslaw:main \"$TMP_GIT_CLONE\" :oldrev \"$oldrev\")" \
                  --eval "(uiop:quit)"
         elif [ $LISP = ccl ]; then
             ccl -e "(ql:quickload 'coleslaw)" \
-                -e "(coleslaw:main \"$TMP_GIT_CLONE\" \"$oldrev\")" \
+                -e "(coleslaw:main \"$TMP_GIT_CLONE\" :oldrev \"$oldrev\")" \
                 -e "(uiop:quit)"
         else
             echo -e "$LISP is not a supported lisp dialect at this time. Exiting.\n"


### PR DESCRIPTION
coleslaw:main got changed to take the old revision as a &key argument, but the example code was not updated.